### PR TITLE
new notification count for both auto confirm/no auto confirm applications

### DIFF
--- a/app/controllers/RecruiterController.java
+++ b/app/controllers/RecruiterController.java
@@ -273,26 +273,38 @@ public class RecruiterController {
                     // if the job post has review application set as auto-confirm the applications automatically, we will count the no. of upcoming interviews and today's interviews,
                     // else we will calculate all the scheduled application which needs action (accept, reject, reschedule)
 
+                    Date yesterday = new Date(System.currentTimeMillis() - 1000L * 60L * 60L * 24L);
+                    Date interviewDate = jpwf.getScheduledInterviewDate();
+
                     if(jpwf.getJobPost().getReviewApplication() != null){
                         if(jpwf.getJobPost().getReviewApplication() == 1){
                             if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_CONFIRMED){
-                                Date yesterday = new Date(System.currentTimeMillis() - 1000L * 60L * 60L * 24L);
-                                Date interviewDate = jpwf.getScheduledInterviewDate();
 
                                 if(interviewDate.after(yesterday)){
                                     //here the interview upcoming and today's
                                     //we are comparing this with yesterday's date as the Date function 'date.after()' new day result
-                                    singleObject.setPendingCount(singleObject.getPendingCount()+1);
+                                    singleObject.setUpcomingCount(singleObject.getUpcomingCount() + 1);
                                 }
+                            } else if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_SCHEDULED){
+                                singleObject.setPendingCount(singleObject.getPendingCount()+1);
                             }
                         } else{
                             if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_SCHEDULED){
                                 singleObject.setPendingCount(singleObject.getPendingCount()+1);
+                            } else if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_CONFIRMED){
+
+                                if(interviewDate.after(yesterday)){
+                                    singleObject.setUpcomingCount(singleObject.getUpcomingCount() + 1);
+                                }
                             }
                         }
                     } else{
                         if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_SCHEDULED){
                             singleObject.setPendingCount(singleObject.getPendingCount()+1);
+                        } else if(jpwf.getStatus().getStatusId() == ServerConstants.JWF_STATUS_INTERVIEW_CONFIRMED){
+                            if(interviewDate.after(yesterday)){
+                                singleObject.setUpcomingCount(singleObject.getUpcomingCount() + 1);
+                            }
                         }
                     }
                     singleObject.setTotalCount(singleObject.getTotalCount()+1);
@@ -322,17 +334,20 @@ public class RecruiterController {
     public static class RecruiterJobPostObject{
         Map<Long, JobPostWorkflow> jobPostWorkflowMap;
         int pendingCount;
+        int upcomingCount;
         int totalCount;
         JobPost jobPost;
 
         public RecruiterJobPostObject() {
             pendingCount = 0;
             totalCount = 0;
+            upcomingCount = 0;
         }
 
-        public RecruiterJobPostObject(Map<Long, JobPostWorkflow> jobPostWorkflowMap, int pendingCount, int totalCount) {
+        public RecruiterJobPostObject(Map<Long, JobPostWorkflow> jobPostWorkflowMap, int pendingCount, int totalCount, int upcomingCount) {
             this.jobPostWorkflowMap = jobPostWorkflowMap;
             this.pendingCount = pendingCount;
+            this.upcomingCount = upcomingCount;
             this.totalCount = totalCount;
         }
 
@@ -366,6 +381,14 @@ public class RecruiterController {
 
         public void setJobPost(JobPost jobPost) {
             this.jobPost = jobPost;
+        }
+
+        public int getUpcomingCount() {
+            return upcomingCount;
+        }
+
+        public void setUpcomingCount(int upcomingCount) {
+            this.upcomingCount = upcomingCount;
         }
     }
 

--- a/public/recruiter/js/recruiter_applied_candidates.js
+++ b/public/recruiter/js/recruiter_applied_candidates.js
@@ -1181,8 +1181,8 @@ function processDataForJobApplications(returnedData) {
             $(".badge").hide();
         } else {
             $(".badge").show();
-            $("#pendingApproval").addClass("newNotification").html(approvalCount + " new");
-            $("#pendingApprovalMobile").addClass("newNotification").html(approvalCount + " new");
+            $("#pendingApproval").addClass("newNotification").html(approvalCount);
+            $("#pendingApprovalMobile").addClass("newNotification").html(approvalCount);
         }
 
         if(pendingCount == 0){

--- a/public/recruiter/js/recruiter_home.js
+++ b/public/recruiter/js/recruiter_home.js
@@ -19,8 +19,8 @@ $(window).load(function() {
             $(".badge").hide();
         } else{
             $(".badge").show();
-            $("#pendingApproval").addClass("newNotification").html(newCount + " new");
-            $("#pendingApprovalMobile").addClass("newNotification").html(newCount + " new");
+            $("#pendingApproval").addClass("newNotification").html(newCount);
+            $("#pendingApprovalMobile").addClass("newNotification").html(newCount);
         }
     }, 100);
 });
@@ -141,6 +141,7 @@ function processDataGetJobPostDetails(returnedData) {
     var jpId = [];
     jobPostList.forEach(function (jobPost) {
         newCount += jobPost.pendingCount;
+        newCount += jobPost.upcomingCount;
         jpId.push(parseInt(jobPost.jobPost.jobPostId));
     });
 

--- a/public/recruiter/js/recruiter_my_jobs.js
+++ b/public/recruiter/js/recruiter_my_jobs.js
@@ -10,8 +10,8 @@ $(window).load(function() {
             $(".badge").hide();
         } else{
             $(".badge").show();
-            $("#pendingApproval").addClass("newNotification").html(newCount + " new");
-            $("#pendingApprovalMobile").addClass("newNotification").html(newCount + " new");
+            $("#pendingApproval").addClass("newNotification").html(newCount);
+            $("#pendingApprovalMobile").addClass("newNotification").html(newCount);
         }
         $(".jobNav").addClass("active");
         $(".jobNavMobile").addClass("active");
@@ -184,6 +184,11 @@ function processDataGenerateJobPostView(returnedData) {
                 newApplication.className = "newCounter";
                 colApplicant.appendChild(newApplication);
 
+                var upcomingCounter = document.createElement('div');
+                upcomingCounter.style = "margin-top: 4px";
+                upcomingCounter.className = "newCounter";
+                colApplicant.appendChild(upcomingCounter);
+
                 var colJobStatus = document.createElement("div");
                 colJobStatus.className = 'col s12 m1 l1';
                 colJobStatus.style = 'margin-top:8px';
@@ -213,7 +218,11 @@ function processDataGenerateJobPostView(returnedData) {
                 if(jobPost.pendingCount > 0){
                     newApplication.textContent = " (" + jobPost.pendingCount + " new)";
                 }
+                if(jobPost.upcomingCount > 0){
+                    upcomingCounter.textContent = " (" + jobPost.upcomingCount + " upcoming)";
+                }
                 newCount += jobPost.pendingCount;
+                newCount += jobPost.upcomingCount;
                 applicantBtn.style = 'text-align: center; font-weight: bold';
                 if(jobPost.totalCount > 0){
                     applicantBtn.className = 'btn-floating btn-small waves-effect waves-light green accent-3';


### PR DESCRIPTION
This is the enhanced code for showing 'new' count in recruiter's dashboard. So there are 2 scenarios:

-> Do not auto confirm interview(s):
  In this case we are counting no. of scheduled interviews which needs action(accept, reject, reschedule). 

-> Auto confirm interview(s):
  In this case we are counting no. of confirmed upcoming interviews 

